### PR TITLE
Admin Panel Login Quick Fix

### DIFF
--- a/Web/Startup.cs
+++ b/Web/Startup.cs
@@ -64,7 +64,7 @@ namespace Web
 
       services.AddAuthentication(option =>
       {
-        option.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+        // option.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
         option.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
         option.DefaultScheme = JwtBearerDefaults.AuthenticationScheme;
       }).AddJwtBearer(options =>
@@ -80,7 +80,6 @@ namespace Web
           IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(Configuration["Jwt:SigningKey"]))
         };
       });
-
     }
 
     // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -106,10 +105,8 @@ namespace Web
       app.UseAuthentication();
       app.UseAuthorization();
 
-            app.UseCors("CORSPolicy");
-
-      context.Database.Migrate();
       app.UseCors("CORSPolicy");
+      context.Database.Migrate();
 
       app.UseEndpoints(endpoints =>
       {


### PR DESCRIPTION
By doing this the admin panel still returns a jwt, but now the admin is able to log into the panel. I'm not sure if this breaks anything else though and it should be reviewed. The only line of code changed was in Startup.cs in the ConfigureServices function at line 67, the DefaultAuthenticateScheme.

```
public void ConfigureServices(IServiceCollection services)

      services.AddAuthentication(option =>
      {
        // option.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
        option.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
        option.DefaultScheme = JwtBearerDefaults.AuthenticationScheme;
```

I found this StackOverflow answer on what the schemes represent 
https://stackoverflow.com/questions/46223407/asp-net-core-2-authenticationschemes